### PR TITLE
Remove Sansheets mention in Sanbase Pro plans

### DIFF
--- a/src/docs/products-and-plans/access-plans/index.md
+++ b/src/docs/products-and-plans/access-plans/index.md
@@ -54,7 +54,6 @@ Here are the access plans for the different Santiment products.
 - No limit to Signals
 - Access to external data providers
 - Access to Sanbase Graphs
-- Access to Sansheets spreadsheets add-on
 
 ## Special restrictions
 

--- a/src/docs/products-and-plans/access-plans/index.md
+++ b/src/docs/products-and-plans/access-plans/index.md
@@ -54,6 +54,7 @@ Here are the access plans for the different Santiment products.
 - No limit to Signals
 - Access to external data providers
 - Access to Sanbase Graphs
+- Bonus: Full access to Sansheets
 
 ## Special restrictions
 


### PR DESCRIPTION
Sansheets is currently available also for free users and we want to keep this. So remove mentioning
that is only available in Sanbase PRO plan and above.