### PR TITLE
Added missing links to navigation

### DIFF
--- a/src/docs/navigation.js
+++ b/src/docs/navigation.js
@@ -38,6 +38,16 @@ export const GUIDES = [
         title:
           'Price - Daily Addresses Divergence, A Primer on On-chain Trading Strategies',
       },
+      {
+        slug:
+          'santiment pro report samples',
+        title: 'Santiment PRO Reports Samples',
+      },
+      {
+        slug:
+          'santiment testimonials',
+        title: 'Santiment Testimonials',
+      },
     ],
   },
   {


### PR DESCRIPTION
## Changes
added two missing links to the navigation, in the "education and use cases" category
<!--- Describe your changes -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My article available in Navigation sidebar and in root article of selected category ([how to do it in README](https://github.com/santiment/academy#add-an-article-into-navigation-sidebar))
- [ ]	My article have [metadata](https://github.com/santiment/academy#metadata) (title, description, date when updated and author)
- [ ]	All added/updated links in article are exist, images shows correctly

