### PR TITLE
fix/homepage-icons

### DIFF
--- a/src/components/Category/Category.module.scss
+++ b/src/components/Category/Category.module.scss
@@ -56,6 +56,7 @@
 }
 
 .icon {
+  fill: none;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Changes

Fixing fill of the icons on the index page (home page).

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My article available in Navigation sidebar and in root article of selected category ([how to do it in README](https://github.com/santiment/academy#add-an-article-into-navigation-sidebar))
- [x]	My article have [metadata](https://github.com/santiment/academy#metadata) (title, description, date when updated and author)
- [x]	All added/updated links in article are exist, images shows correctly

