### PR TITLE
Update format of the note that defi_total_value_locked_[usd/eth] metric is not updated

### DIFF
--- a/src/docs/metrics/defi/index.md
+++ b/src/docs/metrics/defi/index.md
@@ -14,8 +14,10 @@ Metrics related to DeFi protocols
 
 [Flow and balance metrics](/metrics/labeled-balance)
 
+> Temporary these metrics are not updated from 2022-03-15.
+
 Total Value Locked metrics:
-* `defi_total_value_locked_[usd/eth]` - Shows total value locked in DeFi projects, available in USD and ETH. **Temporary these metrics are not updated from 2022-03-15.**
+* `defi_total_value_locked_[usd/eth]` - Shows total value locked in DeFi projects, available in USD and ETH.
 
 ---
 


### PR DESCRIPTION
minor change