### PR TITLE
footer links fixed

### DIFF
--- a/src/components/Footer/links.js
+++ b/src/components/Footer/links.js
@@ -41,7 +41,7 @@ export const categories = [
       {
         children: 'trends',
         name: 'Social trends',
-        href: 'https://app.santiment.net/labs/trends',
+        href: 'https://app.santiment.net/dashboards/social-tool',
       },
       {
         children: 'balance',
@@ -50,8 +50,8 @@ export const categories = [
       },
       {
         children: 'buy',
-        name: 'Buy SAN',
-        href: 'https://academy.santiment.net/san-tokens/how-to-buy-san/',
+        name: 'Buy SAN Tokens',
+        href: 'https://academy.santiment.net/san-tokens/how-to-buy-san-tokens/',
       },
     ],
   },
@@ -76,10 +76,6 @@ export const categories = [
         children: 'Sangraphs',
         name: 'Graphs',
         href: 'https://graphs.santiment.net/',
-      },
-      {
-        name: 'Sanhunters',
-        href: 'https://hunters.santiment.net/',
       },
     ],
   },

--- a/src/components/SantimentProductsTooltip/Products.js
+++ b/src/components/SantimentProductsTooltip/Products.js
@@ -3,7 +3,6 @@ import sanapi from './icons/sanapi.svg'
 import sanbase from './icons/sanbase.svg'
 import insights from './icons/insights.svg'
 import sansheets from './icons/sansheets.svg'
-import sanhunters from './icons/sanhunters.svg'
 
 export const BUSINESS_PRODUCTS = [
   {
@@ -33,12 +32,6 @@ export const CHAIN_PRODUCTS = [
     title: 'SanR',
     description: 'Decentralized marketplace for crypto price signals',
     to: 'https://sanr.app',
-  },
-  {
-    img: sanhunters,
-    title: 'Sanhunters',
-    description: 'Get rewarded for market research and your crypto know-how',
-    to: 'https://hunters.santiment.net',
   },
   {
     img: insights,


### PR DESCRIPTION
## Changes
- `Social trends` and `Buy SAN Tokens` links updated
- `Sanhunters` removed from footer and top menu
<!--- Describe your changes -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My article available in Navigation sidebar and in root article of selected category ([how to do it in README](https://github.com/santiment/academy#add-an-article-into-navigation-sidebar))
- [x]	My article have [metadata](https://github.com/santiment/academy#metadata) (title, description, date when updated and author)
- [x]	All added/updated links in article are exist, images shows correctly

