### PR TITLE
Removed halloween UI

### DIFF
--- a/src/components/ArticleHeadings/ArticleHeadings.js
+++ b/src/components/ArticleHeadings/ArticleHeadings.js
@@ -1,20 +1,8 @@
-import React, { useEffect, useRef } from 'react'
-import AcademySvelte from 'webkit/ui/Halloween/Academy.svelte'
+import React from 'react'
 import { useSidenavItems } from './hooks'
-import { isSSR, usePageHash } from '../../utils/utils'
+import { usePageHash } from '../../utils/utils'
 import cx from 'classnames'
 import styles from './ArticleHeadings.module.scss'
-
-const Halloween = () => {
-  const ref = useRef()
-
-  useEffect(() => {
-    const svelte = new AcademySvelte({ target: ref.current })
-    return () => svelte.$destroy()
-  }, [])
-
-  return <li ref={ref} className={styles.halloween} />
-}
 
 export const ArrowRight = () => (
   <svg
@@ -91,7 +79,6 @@ const ArticleHeadings = ({ tableOfContents, crumbs = [], title }) => {
           </a>
         </li>
       ))}
-      {!isSSR && topic === 'san-tokens' && <Halloween />}
     </ul>
   )
 }

--- a/src/components/ArticleHeadings/ArticleHeadings.module.scss
+++ b/src/components/ArticleHeadings/ArticleHeadings.module.scss
@@ -111,7 +111,3 @@
     }
   }
 }
-
-.halloween {
-  margin-top: 40px;
-}


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->
1. Removed banner from san token page

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My article available in Navigation sidebar and in root article of selected category ([how to do it in README](https://github.com/santiment/academy#add-an-article-into-navigation-sidebar))
- [x]	My article have [metadata](https://github.com/santiment/academy#metadata) (title, description, date when updated and author)
- [x]	All added/updated links in article are exist, images shows correctly

