### PR TITLE
fix/try-catch-scroll-to

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -8,15 +8,19 @@
 
 export { wrapRootElement } from "./src/apollo/wrap-root-element"
 
+const scrollTo = id => () => {
+  try {
+    const el = document.querySelector(id)
+    if (el) return window.scrollTo(0, el.offsetTop - 90)
+  } catch (e) {
+    console.log(e)
+  }
 
-const scrollTo = (id) => () => {
-  const el = document.querySelector(id)
-  if (el) return window.scrollTo(0, el.offsetTop - 90)
   return false
 }
 
 export const onRouteUpdate = ({ location: { hash } }) => {
   if (hash) {
-    window.setTimeout(scrollTo(hash), 10)
+    window.setTimeout(scrollTo(hash.replace("/", "")), 10)
   }
 }


### PR DESCRIPTION
## Changes

`scrollTo` utility wrapped in a try/catch block in order to not break if invalid selector id was passed as an argument

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My article available in Navigation sidebar and in root article of selected category ([how to do it in README](https://github.com/santiment/academy#add-an-article-into-navigation-sidebar))
- [ ]	My article have [metadata](https://github.com/santiment/academy#metadata) (title, description, date when updated and author)
- [ ]	All added/updated links in article are exist, images shows correctly

