### PR TITLE
Add missing information for social metrics

### DIFF
--- a/src/docs/metrics/index.md
+++ b/src/docs/metrics/index.md
@@ -42,6 +42,19 @@ channels, plus custom sentiment measurements analyzing crowd behavior. Includes
 emerging trend words and projects, word clouds to display related words and the
 possibility to enter custom search terms.
 
+All social/sentiment metrics contain <source> or total in the name.
+For example:
+- social_volume_total
+- social_volume_telegram
+- unique_social_volume_total_1d
+Available sources are:
+- 4chan
+- telegram
+- reddit
+- twitter
+- bitcointalk
+- total (combines all sources)
+
 - [Community Messages Count](/metrics/community-messages-count)
 - [Emerging Trends](/metrics/emerging-trends)
 - [Sentiment Metrics](/metrics/sentiment-metrics)

--- a/src/docs/metrics/sentiment-metrics/index.md
+++ b/src/docs/metrics/sentiment-metrics/index.md
@@ -99,6 +99,17 @@ this can be found [here](/metrics/social-volume-metrics/#available-assets).
 
 The metric is available **for any selected asset**.
 
+##### SanAPI
+
+Available under the `sentiment_positive_total` `sentiment_positive_<source>`
+- 4chan
+- telegram
+- reddit
+- twitter
+- bitcointalk
+- youtube_videos
+- total (combines all sources)
+
 #### Availability
 
 |           | Free | Basic | Pro                | Pro+               | Enterprise         |
@@ -135,6 +146,18 @@ Same as [**Positive (Negative) Sentiment**](#positive-negative-sentiment).
 ##### [Sanbase](https://app.santiment.net/s/lL05ManV)
 
 The metric is available **for any selected asset**.
+
+
+##### SanAPI
+
+Available under the `sentiment_balance_total` and `sentiment_balance_<source>`
+- 4chan
+- telegram
+- reddit
+- twitter
+- bitcointalk
+- youtube_videos
+- total (combines all sources)
 
 #### Availability
 
@@ -196,7 +219,7 @@ Same as [**Positive (Negative) Sentiment**](#positive-negative-sentiment).
 
 #### SanAPI
 
-Available under the `sentiment_volume_consumed_total` `sentiment_balance_total` and `sentiment_balance_<source>`
+Available under the `sentiment_volume_consumed_total` `sentiment_volume_consumed_<source>`
 - 4chan
 - telegram
 - reddit

--- a/src/docs/metrics/sentiment-metrics/index.md
+++ b/src/docs/metrics/sentiment-metrics/index.md
@@ -144,7 +144,7 @@ The metric is available **for any selected asset**.
 | SanAPI    | :x:  | :x:   | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Sansheets | :x:  | :x:   | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
-### 3. Sentiment Weighted
+### 3. Sentiment Weighted / Sentiment Volume Consumed
 
 #### Definition
 
@@ -193,6 +193,17 @@ Same as [**Positive (Negative) Sentiment**](#positive-negative-sentiment).
 Same as [**Positive (Negative) Sentiment**](#positive-negative-sentiment).
 
 #### How to Access
+
+#### SanAPI
+
+Available under the `sentiment_volume_consumed_total` `sentiment_balance_total` and `sentiment_balance_<source>`
+- 4chan
+- telegram
+- reddit
+- twitter
+- bitcointalk
+- youtube_videos
+- total (combines all sources)
 
 ##### [Sanbase](https://app.santiment.net/s/p_5roQjX)
 

--- a/src/docs/metrics/sentiment-metrics/index.md
+++ b/src/docs/metrics/sentiment-metrics/index.md
@@ -1,7 +1,7 @@
 ---
 title: Sentiment Metrics
 author: Ivan Klimuk, Santiment authors
-date: 2021-08-24
+date: 2024-03-27
 # REF metrics-hub/metricshub/sentiment_positive.py
 # REF metrics-hub/metricshub/sentiment_negative.py
 # REF metrics-hub/metricshub/sentiment_balance.py

--- a/src/docs/metrics/social-dominance/index.md
+++ b/src/docs/metrics/social-dominance/index.md
@@ -96,10 +96,12 @@ The combined social dominance from all sources is displayed
 Available under the `social_dominance_total` and `social_dominance_total_<source>`
 names, where the available sources are:
 
+- 4chan
 - telegram
 - reddit
 - twitter
 - bitcointalk
+- youtube_videos
 - total (combines all sources)
 
 ### Social Dominance for an asset

--- a/src/docs/metrics/social-dominance/index.md
+++ b/src/docs/metrics/social-dominance/index.md
@@ -1,7 +1,7 @@
 ---
 title: Social Dominance
 author: Santiment Team
-date: 2022-10-18
+date: 2024-03-27
 description: Share of the crypto discussions that refer to an asset/phrase
 # REF metrics-hub/metricshub/social_dominance.py
 ---

--- a/src/docs/metrics/social-volume/index.md
+++ b/src/docs/metrics/social-volume/index.md
@@ -119,10 +119,12 @@ search term](social-volume-search-term.png)
 Available under the `social_volume_total` and `social_volume_total_<source>`
 names, where the available sources are:
 
+- 4chan
 - telegram
 - reddit
 - twitter
 - bitcointalk
+- youtube_videos
 - total (combines all sources)
 
 ### Social Volume for an asset

--- a/src/docs/metrics/social-volume/index.md
+++ b/src/docs/metrics/social-volume/index.md
@@ -1,7 +1,7 @@
 ---
 title: Social Volume
 author: Ivan
-date: 2020-04-13
+date: 2024-03-27
 description: The amount of messages/documents containing a given search term
 # REF metrics-hub/metricshub/social_volume.py
 ---

--- a/src/docs/metrics/unique-social-volume/index.md
+++ b/src/docs/metrics/unique-social-volume/index.md
@@ -20,8 +20,9 @@ There are two separate metrics for the unique social volume:
 
 - unique_social_volume_total_5m
 - unique_social_volume_total_1h
+- unique_social_volume_total_1d
 
-The `5m` and `1h` control what range of data is used. If some spam messages are
+The `5m`, `1h` and `1d` control what range of data is used. If some spam messages are
 posted in the span of 30 minutes, then every one of the six  5-minute buckets would have
 one copy of that message. In the case of `1h` all these messages would be reduced
 to a single one, thus providing more aggresive spam filtering.

--- a/src/docs/metrics/unique-social-volume/index.md
+++ b/src/docs/metrics/unique-social-volume/index.md
@@ -1,7 +1,7 @@
 ---
 title: Unique Social Volume
 author: Ivan
-date: 2021-07-14
+date: 2024-03-27
 description: The amount of messages/documents containing a given search term without spam
 # REF metrics-hub/metricshub/unique_social_volume.py
 ---


### PR DESCRIPTION
## Changes

There are changes in social metrics, we add new sources for metrics.
We have two different names for social volume consumed / weighed sentiment in SanBase and SanAPI.
Add missing part about SanAPI for sentiment metrics

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My article available in Navigation sidebar and in root article of selected category ([how to do it in README](https://github.com/santiment/academy#add-an-article-into-navigation-sidebar))
- [x]	My article have [metadata](https://github.com/santiment/academy#metadata) (title, description, date when updated and author)
- [x]	All added/updated links in article are exist, images shows correctly

