### PR TITLE
Fix github activity metric link

### DIFF
--- a/src/docs/metrics/index.md
+++ b/src/docs/metrics/index.md
@@ -50,7 +50,7 @@ channels, plus custom sentiment measurements analyzing crowd behavior.
 [Development Activity Metrics](/metrics/development-activity) are used to measure a team’s development activity.
 
 - [Development Activity](/metrics/development-activity/development-activity)
-- [Github Activity](/metrics/development-activity/github-activity-metric)
+- [Github Activity](/metrics/development-activity/github-activity)
 - [Development Activity Contributors Count](/metrics/development-activity/development-activity-contributors-count)
 - [Development Activity](/metrics/development-activity/development-activity-contributors-count)
 


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My article available in Navigation sidebar and in root article of selected category ([how to do it in README](https://github.com/santiment/academy#add-an-article-into-navigation-sidebar))
- [ ]	My article have [metadata](https://github.com/santiment/academy#metadata) (title, description, date when updated and author)
- [ ]	All added/updated links in article are exist, images shows correctly

