### PR TITLE
Fix wrong label-fqn links

### DIFF
--- a/src/docs/labels/airdrop-receiver/index.md
+++ b/src/docs/labels/airdrop-receiver/index.md
@@ -9,7 +9,7 @@ description: Airdrop Receiver Label
 
 The airdrop_receiver label is assigned to wallet addresses that have received any airdrops.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/airdrop_receiver:v1`
 

--- a/src/docs/labels/airdrop-sender/index.md
+++ b/src/docs/labels/airdrop-sender/index.md
@@ -11,7 +11,7 @@ The airdrop_sender label is used to identify wallet addresses that are associate
 
 By applying the airdrop_sender label to specific addresses, you can quickly identify wallets that have been involved in initiating and sending airdrops. This label helps provide insights into the participation of wallets in airdrop campaigns and token distributions.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/airdrop_sender:v1`
 

--- a/src/docs/labels/blocked/index.md
+++ b/src/docs/labels/blocked/index.md
@@ -9,7 +9,7 @@ description: Blocked Label
 
 This address has been blocked by an authorized entity.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/blocked:v1`
 

--- a/src/docs/labels/bridge/index.md
+++ b/src/docs/labels/bridge/index.md
@@ -12,7 +12,7 @@ allowing users to access assets that were previously inaccessible.
 They increase liquidity and interoperability between blockchain networks. Examples include Wrapped Bitcoin and the Binance Smart Chain.
 
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/bridge:v1`
 

--- a/src/docs/labels/cefi/index.md
+++ b/src/docs/labels/cefi/index.md
@@ -13,7 +13,7 @@ CeFi platforms typically offer higher speed, liquidity, and convenience compared
 
 CeFi group includes other labels such as [centralized exchange](/labels/centralized-exchange), [fund](/labels/fund) and others. Visit [this page](labels/#domains) to see full child labels list.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/cefi:v1`
 

--- a/src/docs/labels/centralized-exchange/index.md
+++ b/src/docs/labels/centralized-exchange/index.md
@@ -11,7 +11,7 @@ The centralized exchange label is used to identify wallet addresses that belong 
 
 Centralzied exchanges (CEX) are operated by a central authority or entity that manages the exchange, executes trades, and stores users' digital assets. CEXs typically have a user-friendly interface and offer high liquidity, faster transaction processing, and a wide range of trading pairs. 
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/centralized_exchange:v1`
 

--- a/src/docs/labels/charity/index.md
+++ b/src/docs/labels/charity/index.md
@@ -9,7 +9,7 @@ description: Charity label
 
 This label is assigned for project addresses that are involved in charitable or nonprofit endeavors.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/charity:v1`
 

--- a/src/docs/labels/closed/index.md
+++ b/src/docs/labels/closed/index.md
@@ -9,7 +9,7 @@ description: Closed label
 
 Label `closed` used to indicate that an address's owner has announced the end of their project or business operations.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/closed:v1`
 

--- a/src/docs/labels/cold-wallet/index.md
+++ b/src/docs/labels/cold-wallet/index.md
@@ -9,7 +9,7 @@ description: Cold wallet label
 
 Label `cold_wallet` refers to a type of wallet that is commonly used by centralized exchanges or other entities as a secure storage solution for cryptocurrency assets.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/cold_wallet:v1`
 

--- a/src/docs/labels/contract/index.md
+++ b/src/docs/labels/contract/index.md
@@ -9,7 +9,7 @@ description: Smart contract label
 
 The label `contract` denotes any address which is a smart contract.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/contract:v1`
 

--- a/src/docs/labels/dead-address/index.md
+++ b/src/docs/labels/dead-address/index.md
@@ -9,7 +9,7 @@ description: Dead address label
 
 Addresses that can not be owed by anyone and/or used for tokens burning. Also called as cemetary addresses.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/dead_address:v1`
 

--- a/src/docs/labels/decentralized-exchange/index.md
+++ b/src/docs/labels/decentralized-exchange/index.md
@@ -11,7 +11,7 @@ Decentralized exchange label denotes an address belonging to a decentralized exc
 
 Decentralzied exhcnage (DEX) is a decentralized platform that operate on a peer-to-peer (P2P) network, without a central authority or entity. DEXs allow users to trade cryptocurrencies directly with each other, using smart contracts and blockchain technology. Unlike centralzied exchanges (CEX), DEXs offer greater privacy, security, and transparency, as users have full control over their assets and do not need to trust a third party to execute trades. However, DEXs may have lower liquidity, slower transaction processing, and fewer trading pairs compared to CEXs.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/decentralized_exchange:v1`
 

--- a/src/docs/labels/defi/index.md
+++ b/src/docs/labels/defi/index.md
@@ -11,7 +11,7 @@ The DeFi label is used to identify wallet addresses that are involved in decentr
 
 DeFi group includes other labels such as [decentralized exchange](/labels/decentralized-exchange), [stablecoin](/labels/stablecoin) and others. Visit [this page](labels/#domains) to see full child labels list.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/defi:v1`
 

--- a/src/docs/labels/deposit/index.md
+++ b/src/docs/labels/deposit/index.md
@@ -18,7 +18,7 @@ Most common case is a centralized exhcnage deposit. See the details on the pictu
 
 ![deposit_address](deposit-withdrawal.png)
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/deposit:v1`
 

--- a/src/docs/labels/derivatives/index.md
+++ b/src/docs/labels/derivatives/index.md
@@ -13,7 +13,7 @@ where a buyer and a seller engage in a contractual agreement to trade an underly
 These assets are sold at a prearranged time and price. 
 
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/derivatives:v1`
 

--- a/src/docs/labels/dex-user/index.md
+++ b/src/docs/labels/dex-user/index.md
@@ -9,7 +9,7 @@ description: label
 
 The label denotes an address that traded on at least one DEX.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/dex_user:v1`
 

--- a/src/docs/labels/dsproxy/index.md
+++ b/src/docs/labels/dsproxy/index.md
@@ -12,7 +12,7 @@ contract calls in a single transaction. In contrast to vanilla externally owned 
 to interacting with just one contract per transaction, DSProxy provides greater functionality and flexibility for 
 executing complex actions on the Ethereum blockchain.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/dsproxy:v1`
 

--- a/src/docs/labels/erc1155/index.md
+++ b/src/docs/labels/erc1155/index.md
@@ -14,7 +14,7 @@ ERC1155 is a multi-token standard developed on the Ethereum blockchain that allo
 and non-fungible tokens within a single smart contract. They also be used to create semi-fungible tokens, which combine 
 elements of both fungible and non-fungible tokens, providing greater flexibility in token design and functionality.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/erc1155:v1`
 

--- a/src/docs/labels/erc721/index.md
+++ b/src/docs/labels/erc721/index.md
@@ -11,7 +11,7 @@ Denotes a smart contract that follows erc-721 standart.
 
 ERC721 is a standard for non-fungible tokens (NFTs) on the Ethereum blockchain, enabling unique digital assets to be represented and traded on the network.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/erc721:v1`
 

--- a/src/docs/labels/eth2-staking-address/index.md
+++ b/src/docs/labels/eth2-staking-address/index.md
@@ -13,7 +13,7 @@ Staking on the Ethereum 2.0 network involves holding and locking up a minimum of
 Ethereum 2.0 network plays a crucial role in the transition 
 from proof-of-work (PoW) to proof-of-stake (PoS) consensus mechanism, which is more energy-efficient and scalable.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/eth2_staking_address:v1`
 

--- a/src/docs/labels/eth2-staking/index.md
+++ b/src/docs/labels/eth2-staking/index.md
@@ -9,7 +9,7 @@ description: ETH2 Staking label
 
 The eth2_staking label is used to identify wallet addresses that stake ETH
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/eth2_staking:v1`
 

--- a/src/docs/labels/factory/index.md
+++ b/src/docs/labels/factory/index.md
@@ -15,7 +15,7 @@ scratch. This saves time and effort, especially for contracts with similar funct
 A contract factory can also include custom parameters that can be used to personalize each new contract created from the factory. This allows for greater flexibility and customization in the contract creation process.
 
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/factory:v1`
 

--- a/src/docs/labels/fund/index.md
+++ b/src/docs/labels/fund/index.md
@@ -9,7 +9,7 @@ description: Fund label
 
 The fund label is used to identify wallet addresses that belong to investment funds operating in the cryptocurrency space.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/fund:v1`
 

--- a/src/docs/labels/gambling/index.md
+++ b/src/docs/labels/gambling/index.md
@@ -9,7 +9,7 @@ description: Gambling label
 
 The gambling label is used to identify wallet addresses that are involved in gambling activities. This label helps quickly identify addresses associated with online gambling and related transactions.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/gambling:v1`
 

--- a/src/docs/labels/gamefi/index.md
+++ b/src/docs/labels/gamefi/index.md
@@ -9,7 +9,7 @@ description: GameFi label
 
 The gamefi label is used to identify wallet addresses that are actively involved in GameFi activities. GameFi refers to the intersection of gaming and decentralized finance (DeFi), where players can earn, trade, and invest in virtual assets within gaming ecosystems.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/gamefi:v1`
 

--- a/src/docs/labels/genesis/index.md
+++ b/src/docs/labels/genesis/index.md
@@ -14,7 +14,7 @@ These addresses were created during the Genesis block, which is the first block 
 
 In ethereum blockchain there are 8893 genesis addresses.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/genesis:v1`
 

--- a/src/docs/labels/hacked/index.md
+++ b/src/docs/labels/hacked/index.md
@@ -10,6 +10,6 @@ description: Hacked label
 Label `hacked` means that that the owner of this address may have experienced a security breach, 
 and official information about the incident has been officially published.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/hacked:v1`

--- a/src/docs/labels/hot-wallet/index.md
+++ b/src/docs/labels/hot-wallet/index.md
@@ -9,7 +9,7 @@ description: Hot wallet label
 
 Denotes a hot wallet of a centralized exchanges or other entity.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/hot_wallet:v1`
 

--- a/src/docs/labels/lending-user/index.md
+++ b/src/docs/labels/lending-user/index.md
@@ -9,7 +9,7 @@ description: Lending User
 
 These addresses were engaged in lending activities, where they facilitated the process  lending funds.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/lending_user:v1`
 

--- a/src/docs/labels/lending/index.md
+++ b/src/docs/labels/lending/index.md
@@ -12,7 +12,7 @@ Lending labels denotes a crypto lending platforms like aave, compound, etc and a
 Decentralized finance (DeFi) lending projects enable individuals to lend and borrow digital assets without intermediaries. 
 These platforms offer transparency, potentially higher interest rates, but also come with risks such as smart contract vulnerabilities and market volatility. 
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/lending:v1`
 

--- a/src/docs/labels/liquidity/index.md
+++ b/src/docs/labels/liquidity/index.md
@@ -9,7 +9,7 @@ description: Liquidity provider label
 
 Liquidity providers are entities that offer both buy and sell-side liquidity to cryptocurrency.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/liquidity:v1`
 

--- a/src/docs/labels/migration-address/index.md
+++ b/src/docs/labels/migration-address/index.md
@@ -9,7 +9,7 @@ description: Migration Address
 The migration address is utilized for transferring funds between wallets. 
 It is presumed that the migration address is owned by the same individual or entity as the addresses that are associated with it.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/migration_address:v1`
 

--- a/src/docs/labels/miner/index.md
+++ b/src/docs/labels/miner/index.md
@@ -11,7 +11,7 @@ The label denotes the address mining blocks. Address should produce at least 1 b
 
 In ethereum network only PoW miners are considered. There are 8331 miners labels in ethereum blockchain and new labels are not added after the Merge (September 15, 2022).
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/miner:v1`
 

--- a/src/docs/labels/multisig/index.md
+++ b/src/docs/labels/multisig/index.md
@@ -9,7 +9,7 @@ description: MultiSig Label
 
 Multisig wallets are a type of cryptocurrency wallets for which at least two private keys are needed to sign a transaction. Very often a multisig is a smart contract that requires several addresses to initiate a transaction.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/multisig:v1`
 

--- a/src/docs/labels/nft-collection-name/index.md
+++ b/src/docs/labels/nft-collection-name/index.md
@@ -9,7 +9,7 @@ description: NFT collection name label
 
 Name of the [NFT collection](/labels/nft-collection).
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/nft_collection_name->{your_value}:v1`
 

--- a/src/docs/labels/nft-collection-symbol/index.md
+++ b/src/docs/labels/nft-collection-symbol/index.md
@@ -9,7 +9,7 @@ description: NFT collection symbol label
 
 Symbol of the [NFT collection](/labels/nft-collection).
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/nft_collection_symbol->{your_value}:v1`
 

--- a/src/docs/labels/nft-collection/index.md
+++ b/src/docs/labels/nft-collection/index.md
@@ -11,7 +11,7 @@ Any smart contract which is an NFT collection contract should have the `nft-coll
 
 NFT collections are usually identified by their [nft collection name](/labels/nft-collection-name) and [nft collection symbol](/labels/nft-collection-symbol). If the collection has a name or/and symbol that's easily accessible, we create labels for those too.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/nft_collection:v1`
 

--- a/src/docs/labels/nft-influencer/index.md
+++ b/src/docs/labels/nft-influencer/index.md
@@ -9,7 +9,7 @@ description: NFT Influencer
 
 This label denotes an onchain address of some nft influencer.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/nft_influencer:v1`
 

--- a/src/docs/labels/nft-marketplace/index.md
+++ b/src/docs/labels/nft-marketplace/index.md
@@ -11,7 +11,7 @@ NFT marketplace is a platforms where users can buy, sell, and trade NFTs.
 
 By applying the nft_marketplace label to specific addresses, you can quickly identify which wallets are actively engaged in NFT marketplace activities. This label helps provide insights into the involvement of wallets in the dynamic and rapidly growing NFT market.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/nft_marketplace:v1`
 

--- a/src/docs/labels/nft-trader-threshold/index.md
+++ b/src/docs/labels/nft-trader-threshold/index.md
@@ -13,7 +13,7 @@ While the NFT trader label is based on percentiles, the NFT trader threshold use
 The labels are calculated for two N-threshold values: 1000 and 5000.
 
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/nft_trader_threshold->{your_value}:v1`
 

--- a/src/docs/labels/nft-trader/index.md
+++ b/src/docs/labels/nft-trader/index.md
@@ -11,7 +11,7 @@ The NFT trader label is assigned to a group of wallet addresses that have been *
 
 To determine if an address qualifies as an NFT trader (i.e. if the address is active enough), we evaluate its NFT trades count and NFT trading volume against the 97.5 percentile of the NFT trades count and NFT trading volume of all addresses trading NFTs within a recent timeframe. This helps us identify the most active and significant NFT traders in the ecosystem.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/nft_trader:v1`
 

--- a/src/docs/labels/nft-user/index.md
+++ b/src/docs/labels/nft-user/index.md
@@ -9,7 +9,7 @@ description: label
 
 The label denotes an address that traded at least one NFT.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/nft_user:v1`
 

--- a/src/docs/labels/nft/index.md
+++ b/src/docs/labels/nft/index.md
@@ -11,7 +11,7 @@ The NFT label is used to identify wallet addresses that are involved in any NFT 
 
 NFT group includes other labels such as [NFT User](/labels/nft-user), [NFT collection](/labels/nft-collection) and others. Visit this page to see the full child labels list.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/nft:v1`
 

--- a/src/docs/labels/opensea-username/index.md
+++ b/src/docs/labels/opensea-username/index.md
@@ -11,7 +11,7 @@ description: OpenSea Username
 
 This label provides valuable details about the connection between the user's profile on the OpenSea platform and addresses.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/opensea_username->erwwer:v1`
 

--- a/src/docs/labels/owner/index.md
+++ b/src/docs/labels/owner/index.md
@@ -11,7 +11,7 @@ Owner is a standalone label which denotes the person or company which controls a
 
 In most cases Owner label is connected with other labels (such as [centralized_exchange](/labels/centralized-exchange)).
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/owner->{your_value}:v1`
 

--- a/src/docs/labels/proxy/index.md
+++ b/src/docs/labels/proxy/index.md
@@ -13,7 +13,7 @@ For example: Instead of interacting directly with the target contract, all calls
 the request to the intended target contract. This allows for a greater degree of control and flexibility over the 
 contract's behavior.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/proxy:v1`
 

--- a/src/docs/labels/sanctioned/index.md
+++ b/src/docs/labels/sanctioned/index.md
@@ -8,7 +8,7 @@ description: Sanctioned Label
 ## Description
 Label used to mark addresses that were added into sanction list. For example - OFAC Sanction list.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/sanctioned:v1`
 

--- a/src/docs/labels/scam/index.md
+++ b/src/docs/labels/scam/index.md
@@ -9,6 +9,6 @@ description: Scam label
 
 Label `scam` means that address has been linked to scam activity and this information has been publicly disclosed.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/scam:v1`

--- a/src/docs/labels/staking/index.md
+++ b/src/docs/labels/staking/index.md
@@ -11,7 +11,7 @@ DeFi liquid staking projects create tokenized versions of staked assets, allowin
 These projects provide increased flexibility and higher rewards compared to traditional staking.
 
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/liquid_staking:v1`
 

--- a/src/docs/labels/team_wallet/index.md
+++ b/src/docs/labels/team_wallet/index.md
@@ -8,7 +8,7 @@ description: Team wallet label
 ## Description
 
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/team_wallet:v1`
 

--- a/src/docs/labels/used-nft-marketplace/index.md
+++ b/src/docs/labels/used-nft-marketplace/index.md
@@ -9,7 +9,7 @@ description: label
 
 The `used_nft_marketplace` label denotes the marketplaces that NFT user traded on.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/used_nft_marketplace->{your_value}:v1`
 

--- a/src/docs/labels/whale-usd-balance/index.md
+++ b/src/docs/labels/whale-usd-balance/index.md
@@ -58,7 +58,7 @@ $50M|$81k
 $10M|$30k
 $1M|$7.3k
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/whale_usd_balance({asset_name}):v1`
 

--- a/src/docs/labels/whale/index.md
+++ b/src/docs/labels/whale/index.md
@@ -11,7 +11,7 @@ Whale is an address holding a substensial amount of tokens. We sort all addresse
 
 Note that the addresses labelled as whale yesterday might not be a whale any more tomorrow.
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/whale({asset_name}):v1`
 

--- a/src/docs/labels/withdrawal/index.md
+++ b/src/docs/labels/withdrawal/index.md
@@ -13,7 +13,7 @@ The most common case is a centralized exchange (CEX) withdrawal. See the details
 
 ![deposit_address](deposit-withdrawal.png)
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/cex_withdrawal:v1`
 

--- a/src/docs/labels/withdrawn-from/index.md
+++ b/src/docs/labels/withdrawn-from/index.md
@@ -11,7 +11,7 @@ A`withdrawn_from` label is used to identify the entity involved in a withdrawal 
 The most common case is a centralized exchange (CEX) withdrawal. See the details in the image below.
 
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/withdrawn_from->{your_value}:v1`
 

--- a/src/docs/labels/yield/index.md
+++ b/src/docs/labels/yield/index.md
@@ -8,7 +8,7 @@ description: Yield Farming Label
 ## Description
 Label used to mark addresses that are used in Yield Farming activities
 
-## [Label fqn](/label-fqn)
+## [Label fqn](/labels/label-fqn)
 
 `santiment/yield:v1`
 


### PR DESCRIPTION
## Changes

<!--- Describe your changes -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My article available in Navigation sidebar and in root article of selected category ([how to do it in README](https://github.com/santiment/academy#add-an-article-into-navigation-sidebar))
- [ ]	My article have [metadata](https://github.com/santiment/academy#metadata) (title, description, date when updated and author)
- [ ]	All added/updated links in article are exist, images shows correctly

