### PR TITLE
chore: Dockerfile BACKEND_ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ WORKDIR /app
 
 COPY ./ /app
 
+ENV BACKEND_URL="globalThis.env?.BACKEND_URL"
+
 RUN npm install -g yarn --force && yarn install --production
 
 RUN yarn build


### PR DESCRIPTION
## Changes

Setting webkit's BACKEND_URL env variable to use runtime `globalThis.env?. BACKEND_URL` global variable
