### PR TITLE
Remove mentions to soon-to-be-deprecated /graphiql_advanced

### DIFF
--- a/src/content/docs/guides/sanapi/accessing-the-api/index.mdx
+++ b/src/content/docs/guides/sanapi/accessing-the-api/index.mdx
@@ -206,17 +206,6 @@ page.
 After generating your API key, you need to include it as an additional HTTP
 header in the format `Authorization: Apikey <YOUR_OWN_API_KEY>`.
 
-### Authentication with GraphiQL Explorer
-
-Santiment also offers an advanced version of GraphiQL that is particularly useful!\[\]
-for API users:
-[https://api.santiment.net/graphiql_advanced](https://api.santiment.net/graphiql_advanced).
-This version allows users to add HTTP headers, which can be used to include an
-API key and authenticate your requests. To do this, simply add the following
-header: `Authorization: Apikey YOUR_OWN_API_KEY`.
-
-![](./graphiql_header.png)
-
 ### Authentication with curl
 
 Include the `Authorization: Apikey <YOUR_OWN_API_KEY>` header using the `-H` option:


### PR DESCRIPTION
We're releasing one unified, upgraded version of graphiql here:
https://github.com/santiment/sanbase2/pull/5061