### PR TITLE
fix(sanapi-plans) Update historical restriction info for sanbase max plan

### DIFF
--- a/src/content/docs/guides/products-and-plans/sanapi-plans/index.mdx
+++ b/src/content/docs/guides/products-and-plans/sanapi-plans/index.mdx
@@ -15,20 +15,20 @@ Check the [pricing page](https://app.santiment.net/pricing) for the latest plans
 
 ## Plans for Individuals
 
-| Feature            | **Free Plan**                                                     | **Sanbase Pro Plan**                                              | **Sanbase Max Plan**                                                          |
-| ------------------ | ----------------------------------------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| **API Access**     |                                                                   |                                                                   |                                                                               |
-| Free Metrics       | Full access                                                       | Full access                                                       | Full access                                                                   |
-| Restricted Metrics | Partial access:<br/>• 1 year of historical data<br/>• 30 days lag | Partial access:<br/>• 1 year of historical data<br/>• 30 days lag | Partial access:<br/>• 1 year of historical data<br/>• No realtime restriction |
-| **Rate Limits**    |                                                                   |                                                                   |                                                                               |
-| Monthly Limit      | 1,000 API calls                                                   | 5,000 API calls                                                   | 80,000 API calls                                                              |
-| Hourly Limit       | 500 API calls                                                     | 1,000 API calls                                                   | 4,000 API calls                                                               |
-| Per Minute Limit   | 100 API calls                                                     | 100 API calls                                                     | 100 API calls                                                                 |
-| **Sanbase Access** |                                                                   |                                                                   |                                                                               |
-| Free Metrics       | Full access                                                       | Full access                                                       | Full access                                                                   |
-| Restricted Metrics | Partial access:<br/>• 1 year of historical data<br/>• 30 days lag | Partial access:<br/>• 1 year of historical data<br/>• 30 days lag | Partial access:<br/>• 1 year of historical data<br/>• Realtime data           |
-| Alerts Limit       | 3 alerts allowed                                                  | 20 alerts allowed                                                 | 20 alerts allowed                                                             |
-| Insights Access    | Limited access                                                    | Full access                                                       | Full access                                                                   |
+| Feature            | **Free Plan**                                                     | **Sanbase Pro Plan**                                              | **Sanbase Max Plan**                                                           |
+| ------------------ | ----------------------------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| **API Access**     |                                                                   |                                                                   |                                                                                |
+| Free Metrics       | Full access                                                       | Full access                                                       | Full access                                                                    |
+| Restricted Metrics | Partial access:<br/>• 1 year of historical data<br/>• 30 days lag | Partial access:<br/>• 1 year of historical data<br/>• 30 days lag | Partial access:<br/>• 2 years of historical data<br/>• No realtime restriction |
+| **Rate Limits**    |                                                                   |                                                                   |                                                                                |
+| Monthly Limit      | 1,000 API calls                                                   | 5,000 API calls                                                   | 80,000 API calls                                                               |
+| Hourly Limit       | 500 API calls                                                     | 1,000 API calls                                                   | 4,000 API calls                                                                |
+| Per Minute Limit   | 100 API calls                                                     | 100 API calls                                                     | 100 API calls                                                                  |
+| **Sanbase Access** |                                                                   |                                                                   |                                                                                |
+| Free Metrics       | Full access                                                       | Full access                                                       | Full access                                                                    |
+| Restricted Metrics | Partial access:<br/>• 1 year of historical data<br/>• 30 days lag | Partial access:<br/>• 1 year of historical data<br/>• 30 days lag | Partial access:<br/>• 2 years of historical data<br/>• Realtime data           |
+| Alerts Limit       | 3 alerts allowed                                                  | 20 alerts allowed                                                 | 20 alerts allowed                                                              |
+| Insights Access    | Limited access                                                    | Full access                                                       | Full access                                                                    |
 
 ## Plans for Business
 


### PR DESCRIPTION
## Summary
Fix historical data restriction in `sanapi-plans` article `1 year` -> `2 years`