### PR TITLE
fix(mcp-connector) Fix privacy policy link

### DIFF
--- a/src/content/docs/ai-toolkit/mcp-connector/index.mdx
+++ b/src/content/docs/ai-toolkit/mcp-connector/index.mdx
@@ -7,7 +7,7 @@ sidebar:
   order: 10
 ---
 
-import instructionVideo from './instruction.mp4';
+import instructionVideo from './instruction.mp4'
 
 Santiment's MCP (Model Context Protocol) connector gives AI Tools (Claude, ChatGPT, etc.) direct access to crypto market intelligence — on-chain metrics, social sentiment, trending narratives, and analyst insights — so you can research, validate, and analyze without leaving the conversation.
 
@@ -35,6 +35,7 @@ Note: currently this setting is not available in the mobile app, but can be conf
    ```
 
    Then click `Add`.
+
 4. You'll be redirected to Santiment to authorize access via OAuth.
 5. Log in (or create a free account at [app.santiment.net](https://app.santiment.net?utm_source=academy)) and approve the connection.
 6. Start asking questions about any token, metric, or market condition.
@@ -44,7 +45,6 @@ Video how to setup:
 <video autoplay loop muted playsinline>
   <source src={instructionVideo} type="video/mp4" />
 </video>
-
 
 ### Claude Code CLI
 
@@ -156,7 +156,7 @@ For a full list, use the `metrics_and_assets_discovery_tool` with no parameters.
 
 ## Privacy
 
-Santiment collects only the data necessary to serve your requests. No conversation content is stored. See our [Privacy Policy](https://santiment.net/privacy-policy/) for details.
+Santiment collects only the data necessary to serve your requests. No conversation content is stored. See our [Privacy Policy](https://app.santiment.net/privacy-policy/) for details.
 
 ## Support
 


### PR DESCRIPTION
## Summary
Fix link to `privacy-policy` in `mcp-connector` artricle

## Notion card
https://www.notion.so/santiment/Update-Privacy-Policy-3752a82d1361803e9396da84be018009?source=copy_link

## Screenshots
Old link leads to:
<img width="1215" height="374" alt="image" src="https://github.com/user-attachments/assets/08d0b030-0716-4367-9323-5ee546b480f8" />
