### PR TITLE
fix(home): pass ACADEMY_QA type to HeroChat chatbot ctx

### DIFF
--- a/src/components/features/home/HeroChat.svelte
+++ b/src/components/features/home/HeroChat.svelte
@@ -2,7 +2,7 @@
   import { ChatInput, useAIChatbotCtx } from 'san-webkit-next/ui/app/AIChatbot'
   import Button from 'san-webkit-next/ui/core/Button'
 
-  const { aiChatbot } = useAIChatbotCtx()
+  const { aiChatbot } = useAIChatbotCtx({ type: 'ACADEMY_QA' })
 
   const queries = [
     'What is Santiment known for?',


### PR DESCRIPTION
### Description

Added default AIChatbot type

### Notion's task

https://app.notion.com/p/santiment/Fix-Academy-AI-Chat-Issue-3b82a82d136180f484c6dc5232dff59b?source=copy_link