### PR TITLE
fix(robots): stop blocking images

### DIFF
--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -3,9 +3,6 @@ import type { APIRoute } from 'astro'
 const getRobotsTxt = (sitemapURL: URL) => `\
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow: /*.jpg$
-Disallow: /*.png$
-Disallow: /*.gif$
 Sitemap: ${sitemapURL.href}
 `
 


### PR DESCRIPTION
### Description

Google Search has been showing no favicon for academy.santiment.net for months. Root cause: `robots.txt` disallowed all `*.png` URLs, including `/favicon.png`, so Googlebot-Image was never allowed to fetch it.

I think good idea to allow crawlers to get any image. There's no many of them and it might give a small bonus for search via Google Images

<img width="756" height="168" alt="пример" src="https://github.com/user-attachments/assets/a38b8588-eedd-4c93-b7e8-3c8a21d1e59f" />

### Notion's task

https://app.notion.com/p/santiment/Remove-block-for-images-from-robots-txt-3bb2a82d1361807dbf22e8f50a7ecf50?source=copy_link